### PR TITLE
Quickfix: npm ERROR package.json not found

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,10 @@
 npm i --save babel-core webpack webpack-dev-server
 npm i --save-dev babel-loader babel-preset-es2015 babel-preset-react
 npm i --save bignumber.js react react-dom
-npm i --save oo7 oo7-parity oo7-react parity-reactive-ui
+npm i --save oo7 
+npm i --save oo7-parity
+npm i --save oo7-react
+npm i --save parity-reactive-ui
 
 echo "All installed."
 


### PR DESCRIPTION
`npm ERR! Could not install from "node_modules/oo7" as it does not contain a package.json file.` .
It seems the different versions and imports in oo7/oo7-react/oo7-parity/parity-reactive-ui somehow don't play together when installing as one-liner. Could be npm's issue?
@gavofyork 