### PR TITLE
Fixed oo7 was included in the bundle twice when using oo7-parity.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,6 +15,9 @@ module.exports = {
     ]
   },
   resolve: {
-    extensions: ['.js', '.json', '.jsx']
+    extensions: ['.js', '.json', '.jsx'],
+    alias: {
+      oo7: path.resolve('./node_modules/oo7'),
+    }
   }
 };


### PR DESCRIPTION
When using bonds from oo7-parity, it was causing numerous checks like `x instanceof Bond` to fail if `x` is `TransformBond` from oo7-parity, and eventually to string conversion exception. Happened on Windows in both Chrome & Firefox.